### PR TITLE
Fully add optional MIT website option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use it in the directory where you want to create the `LICENSE` file.
 To create [MIT license](https://opensource.org/licenses/MIT), run:
 
 ```Bash
-license-up mit <name> <surname> <website>
+license-up mit <name> <surname> [<website>]
 ```
 
 Where `<website>` is optional. Here is a working example of it.

--- a/main.go
+++ b/main.go
@@ -61,7 +61,11 @@ func main() {
 	}
 	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
 	case mit.FullCommand():
-		mitCreateWithSite(string(*mitName), string(*mitSurname), string(*mitWebsite))
+		if string(*mitWebsite) == "" {
+			mitCreate(string(*mitName), string(*mitSurname))
+		} else {
+			mitCreateWithSite(string(*mitName), string(*mitSurname), string(*mitWebsite))
+		}
 	case bsd2.FullCommand():
 		bsd2Create(string(*bsd2Name), string(*bsd2Surname))
 	case bsd3.FullCommand():


### PR DESCRIPTION
@nikitavoloboev Before, when you ran it without a website, you would get `YEAR-present, NAME SURNAME ()` instead of just `YEAR-present, NAME SURNAME`.