### PR TITLE
Rename `bsd` -> `bsd3`

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ var (
 	bsd2         = app.Command("bsd2", "Create BSD 2-Clause license.")
 	bsd2Name     = bsd2.Arg("name", "Name of license holder.").Required().String()
 	bsd2Surname  = bsd2.Arg("surname", "Surname of license holder.").Required().String()
-	bsd3         = app.Command("bsd", "Create BSD 3-Clause license.")
+	bsd3         = app.Command("bsd3", "Create BSD 3-Clause license.")
 	bsd3Name     = bsd3.Arg("name", "Name of license holder.").Required().String()
 	bsd3Surname  = bsd3.Arg("surname", "Surname of license holder.").Required().String()
 	cc0          = app.Command("cc0", "Create CC0 license.")


### PR DESCRIPTION
@nikitavoloboev This accidentally slipped through the cracks when I was working on #17 ... `bsd` should now be renamed to `bsd3`.